### PR TITLE
Upgrading is invalid path dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "validate"
   ],
   "dependencies": {
-    "is-invalid-path": "^0.1.0"
+    "is-invalid-path": "^1.0.2"
   }
 }


### PR DESCRIPTION
is invalid path has 1.0.2 version which works better with path validation, 
updating dependency from 0.1.1 to 1.0.2 